### PR TITLE
Dockerfile の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.12-alpine AS build
+
+LABEL maintainer "enm10k <enm10k@gmail.com>"
+
+RUN apk add --update ca-certificates git openssh
+ADD . /go/src/github.com/shiguredo/ayame
+RUN cd /go/src/github.com/shiguredo/ayame && \
+    GO111MODULE=on CGO_ENABLED=0 go build -o /usr/bin/ayame
+
+EXPOSE 3000
+WORKDIR /go/src/github.com/shiguredo/ayame
+ENTRYPOINT ["/usr/bin/ayame", "-addr=0.0.0.0:3000"]

--- a/doc/USE.md
+++ b/doc/USE.md
@@ -32,7 +32,7 @@ go 1.12
 ## ビルドする
 
 ```
-$ go build
+$ GO111MODULE=on go get -u && go build
 ```
 
 ## サーバを起動する


### PR DESCRIPTION
# 変更内容

- ビルド時のコマンドに `go get -u` が漏れていたので USE.md を修正
- Dockerfileの追加
  - Docker HubなどにDockerイメージをホストすれば、利用者がGoの開発環境をローカル・マシンに構築する必要がなくなります(代わりにDockerが必要になりますが ...)
  - 開発時の保守性を考慮し multi-stage build を利用した、Dockerイメージの軽量化は行なっていません

# Dockerのビルド & 起動方法

```
$ docker build --no-cache -t ayame:latest .
Sending build context to Docker daemon  8.345MB
Step 1/8 : FROM golang:1.12-alpine AS build
 ---> 2205a315f9c7
Step 2/8 : LABEL maintainer "enm10k <enm10k@gmail.com>"
 ---> Running in 550ee0717b3b
Removing intermediate container 550ee0717b3b
 ---> eee4e2b7f598
Step 3/8 : RUN apk add --update ca-certificates git openssh
 ---> Running in 33b949f739ab
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
(1/16) Installing nghttp2-libs (1.35.1-r0)
(2/16) Installing libssh2 (1.8.0-r4)
(3/16) Installing libcurl (7.64.0-r1)
(4/16) Installing expat (2.2.6-r0)
(5/16) Installing pcre2 (10.32-r1)
(6/16) Installing git (2.20.1-r0)
(7/16) Installing openssh-keygen (7.9_p1-r4)
(8/16) Installing ncurses-terminfo-base (6.1_p20190105-r0)
(9/16) Installing ncurses-terminfo (6.1_p20190105-r0)
(10/16) Installing ncurses-libs (6.1_p20190105-r0)
(11/16) Installing libedit (20181209.3.1-r0)
(12/16) Installing openssh-client (7.9_p1-r4)
(13/16) Installing openssh-sftp-server (7.9_p1-r4)
(14/16) Installing openssh-server-common (7.9_p1-r4)
(15/16) Installing openssh-server (7.9_p1-r4)
(16/16) Installing openssh (7.9_p1-r4)
Executing busybox-1.29.3-r10.trigger
OK: 32 MiB in 31 packages
Removing intermediate container 33b949f739ab
 ---> ee6376576d0d
Step 4/8 : ADD . /go/src/github.com/shiguredo/ayame
 ---> 2b0f0cbefc10
Step 5/8 : RUN cd /go/src/github.com/shiguredo/ayame &&     GO111MODULE=on CGO_ENABLED=0 go build -o /usr/bin/ayame
 ---> Running in 9e598603a69c
go: finding github.com/gorilla/websocket v1.4.0
go: downloading github.com/gorilla/websocket v1.4.0
go: extracting github.com/gorilla/websocket v1.4.0
Removing intermediate container 9e598603a69c
 ---> ab4a7f1c2d0c
Step 6/8 : EXPOSE 3000
 ---> Running in f79fb18784a6
Removing intermediate container f79fb18784a6
 ---> d58eea0f3a0d
Step 7/8 : WORKDIR /go/src/github.com/shiguredo/ayame
 ---> Running in f30778c70de7
Removing intermediate container f30778c70de7
 ---> 3e2cff729825
Step 8/8 : ENTRYPOINT ["/usr/bin/ayame", "-addr=0.0.0.0:3000"]
 ---> Running in 33feff268379
Removing intermediate container 33feff268379
 ---> 7aed4f4f6fa6
Successfully built 7aed4f4f6fa6
Successfully tagged ayame:latest

$ docker run -p 3000:3000 ayame
WebRTC Signaling Server Ayame
 version 19.02.1
 running on http://0.0.0.0:3000 (Press Ctrl+C quit)
```